### PR TITLE
Remove 'Question' prefix in name

### DIFF
--- a/cse40/question.py
+++ b/cse40/question.py
@@ -18,8 +18,11 @@ class Question(object):
     Note that all scoring is in ints.
     """
 
-    def __init__(self, name, max_points, timeout=DEFAULT_TIMEOUT_SEC):
+    def __init__(
+        self, name, max_points, timeout=DEFAULT_TIMEOUT_SEC, default_prefix="Question "
+    ):
         self.name = name
+        self.default_prefix = default_prefix
 
         self.max_points = max_points
         self._timeout = timeout
@@ -115,7 +118,7 @@ class Question(object):
         Get a string that represents the scoring for this question.
         """
 
-        lines = [f"{self.name}: {self.score} / {self.max_points}"]
+        lines = [f"{self.default_prefix}{self.name}: {self.score} / {self.max_points}"]
         if self.message != "":
             for line in self.message.split("\n"):
                 lines.append("   " + line)

--- a/cse40/question.py
+++ b/cse40/question.py
@@ -10,6 +10,7 @@ import cse40.utils
 
 DEFAULT_TIMEOUT_SEC = 60
 
+
 class Question(object):
     """
     Questions are gradeable portions of an assignment.
@@ -17,7 +18,7 @@ class Question(object):
     Note that all scoring is in ints.
     """
 
-    def __init__(self, name, max_points, timeout = DEFAULT_TIMEOUT_SEC):
+    def __init__(self, name, max_points, timeout=DEFAULT_TIMEOUT_SEC):
         self.name = name
 
         self.max_points = max_points
@@ -25,15 +26,17 @@ class Question(object):
 
         # Scoring artifacts.
         self.score = 0
-        self.message = ''
+        self.message = ""
 
-    def grade(self, submission, additional_data = {}):
+    def grade(self, submission, additional_data={}):
         """
         Invoke the scoring method using a timeout and cleanup.
         Return the score.
         """
 
-        helper = functools.partial(self._score_helper, submission, additional_data = additional_data)
+        helper = functools.partial(
+            self._score_helper, submission, additional_data=additional_data
+        )
 
         try:
             success, value = cse40.utils.invoke_with_timeout(self._timeout, helper)
@@ -41,16 +44,16 @@ class Question(object):
             self.fail("Raised an exception: " + traceback.format_exc())
             return 0
 
-        if (not success):
-            if (value is None):
+        if not success:
+            if value is None:
                 self.fail("Timeout (%d seconds)." % (self._timeout))
             else:
-                self.fail("Error durring execution: " + value);
+                self.fail("Error durring execution: " + value)
 
             return 0
 
         # Because we use the helper method, we can only get None back if there was an error.
-        if (value is None):
+        if value is None:
             self.fail("Error running scoring.")
             return 0
 
@@ -59,7 +62,7 @@ class Question(object):
 
         return self.score
 
-    def _score_helper(self, submission, additional_data = {}):
+    def _score_helper(self, submission, additional_data={}):
         """
         Score the question, but make sure to return the score and message so
         multiprocessing can properly pass them back.
@@ -69,11 +72,11 @@ class Question(object):
         return (self.score, self.message)
 
     def check_not_implemented(self, value):
-        if (value is None):
+        if value is None:
             self.fail("None returned.")
             return True
 
-        if (isinstance(value, type(NotImplemented))):
+        if isinstance(value, type(NotImplemented)):
             self.fail("NotImplemented returned.")
             return True
 
@@ -90,8 +93,8 @@ class Question(object):
     def full_credit(self):
         self.score = self.max_points
 
-    def add_message(self, message, score = 0):
-        if (self.message != ''):
+    def add_message(self, message, score=0):
+        if self.message != "":
             self.message += "\n"
         self.message += message
 
@@ -112,8 +115,8 @@ class Question(object):
         Get a string that represents the scoring for this question.
         """
 
-        lines = ["Question %s: %d / %d" % (self.name, self.score, self.max_points)]
-        if (self.message != ''):
+        lines = [f"{self.name}: {self.score} / {self.max_points}"]
+        if self.message != "":
             for line in self.message.split("\n"):
                 lines.append("   " + line)
 
@@ -125,11 +128,11 @@ class Question(object):
         """
 
         return {
-            'name': self.name,
-            'max_points': self.max_points,
-            'timeout': self._timeout,
-            'score': self.score,
-            'message': self.message,
+            "name": self.name,
+            "max_points": self.max_points,
+            "timeout": self._timeout,
+            "score": self.score,
+            "message": self.message,
         }
 
     @staticmethod
@@ -139,8 +142,8 @@ class Question(object):
         Questions constructed with this will not have an implementation for score_question().
         """
 
-        question = Question(data['name'], data['max_points'], data['timeout'])
-        question.score = data['score']
-        question.message = data['message']
+        question = Question(data["name"], data["max_points"], data["timeout"])
+        question.score = data["score"]
+        question.message = data["message"]
 
         return question


### PR DESCRIPTION
This allows more flexible naming in feedback, rather than requiring "Question" to prefix each message.

I also updated the code to use f-strings, which should be more performant.